### PR TITLE
fix install tabs (fixes #12)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
 {% capture include_install %}
 {% include_relative install.md %}
 {% endcapture %}
-{{ include_install | markdownify }}
+{{ include_install | markdownify | replace: '<p>|','<dd>' | replace: '|</p>','</dd>' | replace: '||','</dd><dd>' }}
 
 <div class="large-12 columns">
   <div class="row">

--- a/install.md
+++ b/install.md
@@ -7,15 +7,7 @@
 Select the operating system you are working on.
 
 <dl id="install-tabs" data-tab="" class="tabs contained three-up">
-<dd class="active">
-[OSX](#tab-osx)
-</dd>
-<dd>
-[Linux](#tab-linux)
-</dd>
-<dd>
-[Windows](#tab-pc)
-</dd>
+| [OSX](#tab-osx) || [Linux](#tab-linux) || [Windows](#tab-windows) |
 </dl>
 
 <div id="install-content" class="tabs-content">
@@ -48,7 +40,7 @@ npm install -g t2-cli
 
 </div>
 
-<div id="tab-pc" class="content">
+<div id="tab-windows" class="content">
 
 On Windows, Tessel drivers will install automatically when you plug in.
 

--- a/javascripts/custom/install.js
+++ b/javascripts/custom/install.js
@@ -4,16 +4,16 @@ $(function () {
   var isWindows = navigator.platform.toUpperCase().indexOf('WIN')!==-1;
   var isLinux = navigator.platform.toUpperCase().indexOf('LINUX')!==-1;
 
-  isMac && $('#osx-tab').trigger('click');
-  isWindows && $('#pc-tab').trigger('click');
-  isLinux && $('#linux-tab').trigger('click');
+  isMac && $('[href="#tab-osx"]').trigger('click');
+  isWindows && $('[href="#tab-windows"]').trigger('click');
+  isLinux && $('[href="#tab-linux"]').trigger('click');
 
   // show based on window hash
   var hash = window.location.hash;
   if (hash) {
-    hash = hash.substring(hash.indexOf('#')+1).toLowerCase();
+    hash = hash.substring(hash.indexOf('#')+5).toLowerCase();
     if (['osx', 'linux', 'windows'].indexOf(hash) != -1){
-      $('#'+hash+'-tab').trigger("click");
+      $('[href="#tab-'+hash+'"]').trigger("click");
       foundOS = true;
     }
   }
@@ -68,4 +68,4 @@ $(function () {
       anchor.append(tempContent);
     }
   }
-})
+});


### PR DESCRIPTION
At some point `markdownify` started adding superfluous `p`-tags which broke Foundation's tab handling script, had to work around this.
