### PR TITLE
fixed forum footer for modules

### DIFF
--- a/modules/accelerometer.md
+++ b/modules/accelerometer.md
@@ -143,7 +143,7 @@ What else can you do with a accelerometer module? Try a [community-created proje
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [accelerometer forums](http://forums.tessel.io/category/accelerometer).
+If you run into any issues you can check out the [accelerometer forums](https://forums.tessel.io/c/modules/accelerometer).
 
 </div>
 </div>

--- a/modules/ambient.md
+++ b/modules/ambient.md
@@ -154,7 +154,7 @@ What else can you do with an ambient module? Try a [community-created project.](
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [ambient forums](http://forums.tessel.io/category/ambient).
+If you run into any issues you can check out the [ambient forums](https://forums.tessel.io/c/modules/ambient).
 
 </div>
 </div>

--- a/modules/audio.md
+++ b/modules/audio.md
@@ -108,7 +108,7 @@ To see what else you can do with the USB audio module, read the [tessel-av](http
 
 What else can you do with an audio module? What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [audio forums](https://forums.tessel.io/c/modules/audio).
+If you run into any issues you can check out the [audio forums](https://forums.tessel.io/c/usb-modules/audio).
 
 </div>
 </div>

--- a/modules/audio.md
+++ b/modules/audio.md
@@ -108,7 +108,7 @@ To see what else you can do with the USB audio module, read the [tessel-av](http
 
 What else can you do with an audio module? What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [module forums](http://forums.tessel.io/c/modules).
+If you run into any issues you can check out the [audio forums](https://forums.tessel.io/c/modules/audio).
 
 </div>
 </div>

--- a/modules/ble.md
+++ b/modules/ble.md
@@ -113,7 +113,7 @@ What else can you do with a BLE module? Get inspired by a [community-created pro
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [module forums](http://forums.tessel.io/c/modules).
+If you run into any issues you can check out the [ble forums](https://forums.tessel.io/c/modules/ble).
 
 </div>
 </div>

--- a/modules/ble.md
+++ b/modules/ble.md
@@ -113,7 +113,7 @@ What else can you do with a BLE module? Get inspired by a [community-created pro
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [ble forums](https://forums.tessel.io/c/modules/ble).
+If you run into any issues you can check out the [ble forums](https://forums.tessel.io/c/usb-modules/ble).
 
 </div>
 </div>

--- a/modules/camera.md
+++ b/modules/camera.md
@@ -116,7 +116,7 @@ What else can you do with a camera module? Get inspired by a [community-created 
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [camera forums](https://forums.tessel.io/c/modules/camera).
+If you run into any issues you can check out the [camera forums](https://forums.tessel.io/c/usb-modules/camera).
 
 </div>
 </div>

--- a/modules/camera.md
+++ b/modules/camera.md
@@ -20,7 +20,7 @@ Make a directory inside your "tessel-code" folder called "camera", change direct
 <div class="row">
 <div class="large-6 columns">
 
-Plug Tessel into your computer via USB, then plug the camera module into either of Tessel's USB ports. You will also need a [UVC compatible USB camera](https://tessel.io/modules#tessel-av). 
+Plug Tessel into your computer via USB, then plug the camera module into either of Tessel's USB ports. You will also need a [UVC compatible USB camera](https://tessel.io/modules#tessel-av).
 
 </div>
 <div class="large-6 columns">
@@ -82,7 +82,7 @@ Save the file.
 
 In your command line, `t2 run camera.js`
 
-Hooray! You should see the following in your terminal: 
+Hooray! You should see the following in your terminal:
 
 ![](http://i.imgur.com/8JdxCON.gif)
 
@@ -93,7 +93,7 @@ Hooray! You should see the following in your terminal:
 
 To see what else you can do with the USB camera module, read the [tessel-av](https://github.com/tessel-av) documentation.
 
-- Try connecting a button to your Tessel 2 and use it as a shutter. 
+- Try connecting a button to your Tessel 2 and use it as a shutter.
 - Use an USB storage drive to store many photos.
 
 
@@ -116,7 +116,7 @@ What else can you do with a camera module? Get inspired by a [community-created 
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [module forums](http://forums.tessel.io/c/modules).
+If you run into any issues you can check out the [camera forums](https://forums.tessel.io/c/modules/camera).
 
 </div>
 </div>

--- a/modules/climate.md
+++ b/modules/climate.md
@@ -156,7 +156,7 @@ What else can you do with a climate module? Try a [community-created project.](h
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [climate forums](http://forums.tessel.io/category/climate).
+If you run into any issues you can check out the [climate forums](https://forums.tessel.io/c/modules/climate).
 
 </div>
 </div>

--- a/modules/gps.md
+++ b/modules/gps.md
@@ -167,7 +167,7 @@ What else can you do with a GPS module? Try a [community-created project.](http:
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [GPS forums](http://forums.tessel.io/category/gps).
+If you run into any issues you can check out the [gps forums](https://forums.tessel.io/c/modules/gps).
 
 </div>
 </div>

--- a/modules/ir.md
+++ b/modules/ir.md
@@ -160,7 +160,7 @@ What else can you do with a IR module? Try a [community-created project.](http:/
 
 What are you making? [Share your invention!](http://tessel.hackster.io/)
 
-If you run into any issues you can check out the [IR forums](http://forums.tessel.io/category/ir).
+If you run into any issues you can check out the [ir forums](https://forums.tessel.io/c/modules/ir).
 
 </div>
 </div>

--- a/modules/relay.md
+++ b/modules/relay.md
@@ -177,7 +177,7 @@ What else can you do with a relay module? Try a [community-created project.](htt
 
 What are you making? [Share your invention!](http://tessel.hackster.io/)
 
-If you run into any issues you can check out the [relay forums](http://forums.tessel.io/category/relay).
+If you run into any issues you can check out the [relay forums](https://forums.tessel.io/c/modules/relay).
 
 </div>
 </div>

--- a/modules/rfid.md
+++ b/modules/rfid.md
@@ -148,7 +148,7 @@ What else can you do with a RFID module? Try a [community-created project.](http
 
 What are you making? [Share your invention!](http://tessel.hackster.io/)
 
-If you run into any issues you can check out the [RFID forums](http://forums.tessel.io/category/rfid).
+If you run into any issues you can check out the [rfid forums](https://forums.tessel.io/c/modules/rfid).
 
 </div>
 </div>

--- a/modules/servo.md
+++ b/modules/servo.md
@@ -209,7 +209,7 @@ What else can you do with a servo module? Try a [community-created project.](htt
 
 What are you making? [Share your invention!](http://tessel.hackster.io/)
 
-If you run into any issues you can check out the [servo forums](http://forums.tessel.io/category/servo).
+If you run into any issues you can check out the [servo forums](https://forums.tessel.io/c/modules/servo).
 
 </div>
 </div>

--- a/modules/storage.md
+++ b/modules/storage.md
@@ -108,7 +108,7 @@ What else can you do with a USB mass storage device? Get inspired by a [communit
 
 What are you making? [Share your invention!](//tessel.io/projects)
 
-If you run into any issues you can check out the [module forums](http://forums.tessel.io/c/modules).
+If you run into any issues you can check out the [storage forums](https://forums.tessel.io/c/usb-modules/storage).
 
 </div>
 </div>


### PR DESCRIPTION
About half of the modules have forum links which are broken.  I've gone through all the module docs and made the link point to the appropriate module tag in the forums.  The only exception is "storage", which doesn't have a tag as far as I can tell.
