### PR TITLE
update docs for long wifi network names or passwords with spaces

### DIFF
--- a/wifi.md
+++ b/wifi.md
@@ -23,7 +23,11 @@ Tessel 2 has robust Wifi built into the board. Let's get connected!
 
 To connect to a new network, enter in your command line (without brackets)
 
-`t2 wifi -n <network-name> -p <password>`
+`t2 wifi -n <network-name> -p <password>`  
+
+
+_Note: if you have spaces in your network name, or password, add quotes around the network name and/or password_  
+`t2 wifi -n "<network name with spaces>" -p "<password with spaces>"`
 
 The password flag is optional. Tessel 2 will save network credentials and attempt to reconnect automatically on startup.
 


### PR DESCRIPTION
As a new user, one of the things I found confusing was trying to connect my tessel-2 to my wifi.  Because I have spaces in the name and password, the command provided in the docs did not work.  The error it gave initially made me think something was wrong with the hardware.  I had to do some digging in the forums to find the answer.  Here I've updated the docs to help clear up confusion for new users in the future.
