### PR TITLE
fix(modules/camera): changes port from default mjpg_streamer port

### DIFF
--- a/modules/camera.md
+++ b/modules/camera.md
@@ -52,7 +52,7 @@ Create a server that responds to every request by taking a picture and piping it
 var av = require('tessel-av');
 var os = require('os');
 var http = require('http');
-var port = 8080;
+var port = 8000;
 var camera = new av.Camera();
 
 http.createServer((request, response) => {


### PR DESCRIPTION
According to the [`tessel-av`](https://github.com/tessel/tessel-av#avcamera), the default video server (`mjpg_streamer`) port is 8080, so the example code results in an `EADDRINUSE` error. This update will result in a successful demo. 

Fixes #151 
