### PR TITLE
fall back to default OS monospace font for code blocks

### DIFF
--- a/stylesheets/tessel.scss
+++ b/stylesheets/tessel.scss
@@ -67,7 +67,7 @@ textarea {
 }
 code {
   word-wrap: break-word;
-  font-family: Andale Mono;
+  font-family: Andale Mono, monospace;
 }
 .box {
   border: 1px solid #dbdbdb;

--- a/stylesheets/tessel.scss
+++ b/stylesheets/tessel.scss
@@ -67,7 +67,7 @@ textarea {
 }
 code {
   word-wrap: break-word;
-  font-family: Andale Mono, monospace;
+  font-family: Andale Mono, Consolas, monospace;
 }
 .box {
   border: 1px solid #dbdbdb;


### PR DESCRIPTION
Hello lovely folks 👋 

Was using the t2 start guide on Windows today and it looks beautiful 💅 
A minor nit on the code blocks that I saw though. If you don't have `Andale Mono` installed on your computer, the font falls back to a serif font, which looks a bit weird. I added a `monospace` fallback to fix this in the stylesheet, hope that looks alright!

Before:

![2017-03-13 17_05_04-tessel installation](https://cloud.githubusercontent.com/assets/1411284/23875502/0944165a-0810-11e7-8618-43c75edc8b00.png)

After:

![2017-03-13 17_05_30-tessel installation](https://cloud.githubusercontent.com/assets/1411284/23875503/0af6800a-0810-11e7-80f9-00444792c2d9.png)

I compiled this with Jekyll locally (where I took the 'after' screenshot) and it's displaying as expected.

Thanks for all the hard work on Tessel, goes without saying 💐 
